### PR TITLE
Richer pre-deploy metadata to handle bytecode optimizations

### DIFF
--- a/examples/hardhat/hardhat.config.js
+++ b/examples/hardhat/hardhat.config.js
@@ -17,5 +17,13 @@ task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
  * @type import('hardhat/config').HardhatUserConfig
  */
 module.exports = {
-  solidity: "0.8.4",
+  solidity: {
+    version: "0.8.13",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+    },
+  },
 };

--- a/src/core/builder/brownie.ts
+++ b/src/core/builder/brownie.ts
@@ -35,6 +35,7 @@ export class BrownieBuilder extends BaseBuilder {
     const files: string[] = [];
     this.findFiles(contractsPath, /^.*(?<!dbg)\.json$/, files);
 
+    // TODO find a way to extract compiler metadata from brownie artifacts
     for (const file of files) {
       logger.debug("Processing:", file.replace(contractsPath, ""));
       const contractName = basename(file, ".json");

--- a/src/core/builder/builder-base.ts
+++ b/src/core/builder/builder-base.ts
@@ -26,11 +26,13 @@ export abstract class BaseBuilder implements IBuilder {
     let ipfsHash;
     try {
       ipfsHash = extractIPFSHashFromBytecode(bytecode);
-    } catch (e) {}
+    } catch (e) {
+      logger.debug(`Error extracting IPFS hash from '${name}': ${e}`);
+    }
 
     if (!ipfsHash) {
       logger.debug(
-        `Cannot resolve build metadata IPFS hash for contract '${name}'. Skipping ${bytecode}`,
+        `Cannot resolve build metadata IPFS hash for contract '${name}'. Skipping.`,
       );
       return false;
     }

--- a/src/core/builder/hardhat.ts
+++ b/src/core/builder/hardhat.ts
@@ -68,16 +68,29 @@ export class HardhatBuilder extends BaseBuilder {
     )) {
       // TODO this fragile logic to only process contracts that are in the sources dir
       if (!contractPath.startsWith(sourcesDir.replace("/", ""))) {
+        logger.debug("Skipping", contractPath, "(not part of sources)");
         continue;
       }
       for (const [contractName, contractInfo] of Object.entries(
         contractInfos as any,
       )) {
         const info = contractInfo as any;
+
+        if (
+          !info.evm ||
+          !info.evm.bytecode ||
+          !info.evm.bytecode.object ||
+          !info.metadata
+        ) {
+          logger.debug("Skipping", contractPath, "(no bytecode or metadata)");
+          continue;
+        }
+
         const bytecode = info.evm.bytecode.object;
+        const deployedBytecode = info.evm.deployedBytecode.object;
         const metadata = info.metadata;
 
-        if (this.shouldProcessContract(bytecode, contractName)) {
+        if (this.shouldProcessContract(deployedBytecode, contractName)) {
           contracts.push({
             metadata,
             bytecode,

--- a/src/core/builder/solc.ts
+++ b/src/core/builder/solc.ts
@@ -109,9 +109,10 @@ export class SolcBuilder extends BaseBuilder {
 
       const contractInfo = JSON.parse(contractJsonFile);
       const bytecode = contractInfo.evm.bytecode.object;
+      const deployedBytecode = contractInfo.evm.deployedBytecode.object;
       const metadata = contractInfo.metadata;
 
-      if (this.shouldProcessContract(bytecode, contractName)) {
+      if (this.shouldProcessContract(deployedBytecode, contractName)) {
         contracts.push({
           metadata,
           bytecode,

--- a/src/core/builder/truffle.ts
+++ b/src/core/builder/truffle.ts
@@ -24,7 +24,7 @@ export class TruffleBuilder extends BaseBuilder {
     const loader = spinner("Compiling...");
     try {
       existsSync(buildPath) && rmSync(buildPath, { recursive: true });
-      execSync("npx truffle compile");
+      execSync("npx --yes truffle compile");
     } catch (e) {
       loader.fail("Compilation failed");
       throw e;
@@ -41,8 +41,9 @@ export class TruffleBuilder extends BaseBuilder {
       const contractName = contractInfo.contractName;
       const metadata = contractInfo.metadata;
       const bytecode = contractInfo.bytecode;
+      const deployedBytecode = contractInfo.deployedBytecode;
 
-      if (this.shouldProcessContract(bytecode, contractName)) {
+      if (this.shouldProcessContract(deployedBytecode, contractName)) {
         contracts.push({
           metadata,
           bytecode,

--- a/src/core/helpers/ipfs.ts
+++ b/src/core/helpers/ipfs.ts
@@ -1,3 +1,4 @@
+import { logger } from "./logger";
 import { decodeFirstSync } from "cbor";
 import { UnixFS } from "ipfs-unixfs";
 import { DAGNode } from "ipld-dag-pb";
@@ -26,20 +27,18 @@ export async function getIPFSHash(str: string) {
 export function extractIPFSHashFromBytecode(
   bytecode: string,
 ): string | undefined {
-  try {
-    const numericBytecode = hexToBytes(bytecode);
-    const cborLength: number =
-      numericBytecode[numericBytecode.length - 2] * 0x100 +
-      numericBytecode[numericBytecode.length - 1];
-    const bytecodeBuffer = Buffer.from(
-      numericBytecode.slice(numericBytecode.length - 2 - cborLength, -2),
-    );
-    const cborData = decodeFirstSync(bytecodeBuffer);
-    if (cborData["ipfs"]) {
-      const uri = toB58String(cborData["ipfs"]);
-      return uri;
-    }
-  } catch (e) {}
+  const numericBytecode = hexToBytes(bytecode);
+  const cborLength: number =
+    numericBytecode[numericBytecode.length - 2] * 0x100 +
+    numericBytecode[numericBytecode.length - 1];
+  const bytecodeBuffer = Buffer.from(
+    numericBytecode.slice(numericBytecode.length - 2 - cborLength, -2),
+  );
+  const cborData = decodeFirstSync(bytecodeBuffer);
+  if (cborData["ipfs"]) {
+    const uri = toB58String(cborData["ipfs"]);
+    return uri;
+  }
   return undefined;
 }
 


### PR DESCRIPTION
The deployable bytecode cannot reliably fetch metadata from it because of compiler optimizations. The deployed bytecode however is reliable. For the deploy step, use the 'predeploy' metadata that the CLI produces instead of the bytecode alone.