### PR TITLE
Track Solidity SDK usage in contracts deployed via thirdweb-deploy

### DIFF
--- a/src/common/processor.ts
+++ b/src/common/processor.ts
@@ -173,7 +173,7 @@ export function getUrl(
   command: string,
   projectType: string,
   options: any,
-  usesSolditySDK?: boolean
+  usesSoliditySDK?: boolean
 ) {
   let url;
   if (hashes.length == 1) {
@@ -194,7 +194,7 @@ export function getUrl(
   if (options.ci) {
     url.searchParams.append("utm_content", "ci");
   }
-  if(usesSolditySDK){
+  if(usesSoliditySDK){
     url.searchParams.append("utm_term", "solidity-sdk");    
   }
   return url;

--- a/src/common/processor.ts
+++ b/src/common/processor.ts
@@ -110,6 +110,10 @@ export async function processProject(
   }
 
   const loader = spinner("Uploading contract data...");
+
+  const soliditySDKPackage = "@thirdweb-dev/contracts";
+  let usesSoliditySDK = false;
+
   try {
     for (let i = 0; i < selectedContracts.length; i++) {
       const contract = selectedContracts[i];
@@ -122,6 +126,9 @@ export async function processProject(
           await Promise.all(
             batch.map(async (c) => {
               const file = readFileSync(c, "utf-8");
+              if(file.includes(soliditySDKPackage)) {
+                usesSoliditySDK = true;
+              }
               return await storage.uploadSingle(file);
             }),
           );
@@ -154,7 +161,7 @@ export async function processProject(
     );
     loader.succeed("Upload successful");
 
-    return getUrl(combinedURIs, command, projectType, options);
+    return getUrl(combinedURIs, command, projectType, options, usesSoliditySDK);
   } catch (e) {
     loader.fail("Error uploading metadata");
     throw e;
@@ -166,6 +173,7 @@ export function getUrl(
   command: string,
   projectType: string,
   options: any,
+  usesSolditySDK?: boolean
 ) {
   let url;
   if (hashes.length == 1) {
@@ -185,6 +193,9 @@ export function getUrl(
   url.searchParams.append("utm_medium", projectType);
   if (options.ci) {
     url.searchParams.append("utm_content", "ci");
+  }
+  if(usesSolditySDK){
+    url.searchParams.append("utm_term", "solidity-sdk");    
   }
   return url;
 }


### PR DESCRIPTION
For the `thirdweb deploy` command:
- we check whether any included Solidity source file contains the string "@thirdweb-dev/contracts". 
- If yes, then we append "utm_term=solidity-sdk" to the output deploy link and track this as an instance of a custom contract deployed via `thirdweb deploy` that uses the Solidity SDK.